### PR TITLE
Fix build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,6 @@
 module.exports = function(eleventyConfig) {
     
-    eleventyConfig.addPassthroughCopy('./src/assets');
+    eleventyConfig.addPassthroughCopy('src/assets');
 
     return{
         dir:{

--- a/src/.eleventyignore
+++ b/src/.eleventyignore
@@ -1,0 +1,1 @@
+assets/vendor


### PR DESCRIPTION
As mentioned on Discord:

1. Move .eleventy.js to the top level so it’s recognized and the paths are correct.
2. Add `assets/vendor` to .eleventyignore so the JSON files under it aren’t interpreted as data files (which made Eleventy try to parse the `tag` values inside them as arrays).